### PR TITLE
feat: full-check workflow

### DIFF
--- a/.github/workflows/evm-lint.yml
+++ b/.github/workflows/evm-lint.yml
@@ -1,3 +1,5 @@
+# DEPRECATED: see ./full-check.yml
+# Kept for backward compatibility, but will be removed in the future
 name: "Lint an EVM project"
 
 on: "workflow_call"

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,0 +1,42 @@
+name: "Full check a project"
+
+on:
+  workflow_call:
+    inputs:
+      check_command:
+        default: "full:check"
+        description: 'The lint command to run (default: "full:check)"'
+        required: false
+        type: string
+      install_foundry:
+        default: true
+        description: "Whether to install Foundry (default: true)"
+        required: false
+        type: boolean
+
+jobs:
+  evm-lint:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Check out the repo"
+        uses: "actions/checkout@v4"
+
+      - name: "Install Foundry"
+        if: ${{ inputs.install_foundry }}
+        uses: "foundry-rs/foundry-toolchain@v1"
+
+      - name: "Install Bun"
+        uses: "oven-sh/setup-bun@v2"
+        with:
+          bun-version: "latest"
+
+      - name: "Install the Node.js dependencies"
+        run: "bun install --frozen-lockfile"
+
+      - name: "Full check the code"
+        run: "bun run ${{ inputs.check_command }}" # Biome, Forge, Prettier, Solhint, etc.
+
+      - name: "Add summary"
+        run: | # shell
+          echo "## Full Check result" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Passed" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# Github Actions Utils
+# 🛠️ Github Actions Utils
 
 Reusable GitHub Actions utilities for Sablier projects.
 
-## Actions
+## 🔧 Actions
 
 | Name                                          | Description        |
 | --------------------------------------------- | ------------------ |
 | [cache](.github/actions/evm-cache/action.yml) | Cache EVM projects |
 
-## Workflows
+## 🔄 Workflows
 
 ### EVM
 
 | Name                                                     | Description                                                |
 | -------------------------------------------------------- | ---------------------------------------------------------- |
 | [bulloak-check](.github/workflows/bulloak-check.yml)     | Check with Bulloak that Solidity tests conform to BTT spec |
-| [evm-lint](.github/workflows/evm-lint.yml)               | Lint an EVM project                                        |
+| [full-check](.github/workflows/full-check.yml)           | Full check a project                                       |
 | [forge-build](.github/workflows/forge-build.yml)         | Build a Forge project                                      |
 | [forge-coverage](.github/workflows/forge-coverage.yml)   | Measure test coverage for a Forge project                  |
 | [forge-test](.github/workflows/forge-test.yml)           | Test a Forge project                                       |
@@ -27,7 +27,7 @@ Reusable GitHub Actions utilities for Sablier projects.
 | --------------------------------------------- | -------------------------------------- |
 | [cron-stale](.github/workflows/cron-tale.yml) | Cron job to close stale issues and PRs |
 
-## Notes
+## 📝 Notes
 
 - The utilities are opinionated and may not fit your needs. For example, we use Bun for managing Node.js dependencies
   and running scripts.
@@ -35,23 +35,25 @@ Reusable GitHub Actions utilities for Sablier projects.
   `forge-build` workflow handles this automatically. You may need to run `forge-build` before, for example,
   `forge-coverage`.
 
-## References
+## 📚 References
 
 - [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
 - [Sharing actions and workflows with your organization](https://docs.github.com/en/actions/creating-actions/sharing-actions-and-workflows-with-your-organization)
 - [How to start using reusable workflows with GitHub Actions](https://github.blog/2022-02-10-using-reusable-workflows-github-actions/)
 
-## Dependents
+## 🔗 Dependents
 
-A list of dependent repositories.
-
-If we make changes to this repo, we may need to update the CI workflows upstream.
+Repositories that depend on this project. If we make changes here, we may need to update CI workflows in these
+repositories.
 
 - [sablier-labs/airdrops](https://github.com/sablier-labs/airdrops)
 - [sablier-labs/evm-utils](https://github.com/sablier-labs/evm-utils)
+- [sablier-labs/deployments](https://github.com/sablier-labs/deployments)
+- [sablier-labs/indexers](https://github.com/sablier-labs/indexers)
+- [sablier-labs/interfaces](https://github.com/sablier-labs/interfaces)
 - [sablier-labs/flow](https://github.com/sablier-labs/flow)
 - [sablier-labs/lockup](https://github.com/sablier-labs/lockup)
 
-## License
+## 📄 License
 
 This project is licensed under MIT.


### PR DESCRIPTION
FYI @sablier-labs/evm, I implemented this workflow because we're switching from Prettier+ESLint to [Biome](https://github.com/sablier-labs/interfaces/issues/1556), and Biome uses `check`.

I also made the workflow more general purpose by allowing users to pass an arbitrary command that gets executed when running `bun run` (instead of using a hard-coded `bun run lint`).